### PR TITLE
Cleaned up some event detail stuff

### DIFF
--- a/controllers/events.js
+++ b/controllers/events.js
@@ -83,7 +83,7 @@ function saveEvent(request, response){
   var month = checkIntRange(request, 'month', 0, 11, contextData);
   var day = checkIntRange(request, 'day', 1, 31, contextData);
   var hour = checkIntRange(request, 'hour', 0, 23, contextData);
-  
+  var minute = checkIntRange(request, 'minute', 0, 30, contextData);
  
   if (validator.isURL(request.body.image) === false) {
     contextData.errors.push('Your image must be a URL');
@@ -99,7 +99,7 @@ function saveEvent(request, response){
       title: request.body.title,
       location: request.body.location,
       image: request.body.image,
-      date: new Date(),
+      date: new Date(request.body.year, request.body.month, request.body.day, request.body.hour, request.body.minute),
       attending: []
     };
     events.all.push(newEvent);

--- a/views/event-detail.html
+++ b/views/event-detail.html
@@ -5,7 +5,7 @@
 <p>
     <img id="image" src={{event.image}}>
     </p>
-<p>Date and Time: <span id="date">{{event.date}}</span></p>
+<p>Date and Time: <span id="date">{{event.date|prettyDate}}</span></p>
 <p>Location: <span id="location">{{event.location}}</span></p>
 <p>Attendees:</p>
 <ul id="attendees">

--- a/views/event.html
+++ b/views/event.html
@@ -4,15 +4,11 @@
   <div>
     {% include "fragments/events-list.html" %}
   </div>
+  <br>
   <div>
     <a href="/events/new">Create a new event</a>
   </div>
-
+  <br>
 {% endblock %}
 
-{% block footer %}
-  <footer>
-    Look at me customize the footer. The time is now {{time}}.
-    <a href="/about">About us</a>.
-  </footer>
-{% endblock %}
+

--- a/views/fragments/events-list.html
+++ b/views/fragments/events-list.html
@@ -2,7 +2,7 @@
   {% for event in events %}
     <li class="event" id="event-{{event.id}}">
       <a href="/events/{{event.id}}">{{event.title}}:</a>
-      <time datetime="{{event.date}}">{{event.date|prettyDate}}</time>
+      <time datetime="{{event.date}}">{{event.date|prettyDate}}</time>.
       {{event.attending.length}} attending so far.
     </li>
   {% endfor %}


### PR DESCRIPTION
When you create an event, the site was inserting the current date and time instead of the date and time you enter in the form. I fixed the event.js controller to correct that. 

I also cleaned up the format of the Browse Events page a little bit, and I changed the format of the date/time on the Event Detail page to have a "prettyDate" format. No more Greenwich Mean Time!
