### PR TITLE
Improved formatting of event lists

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -36,6 +36,23 @@ ul#bottomofpage li{
    display: inline;
    padding: 0px 10px 0px 10px;
 }
+
+.events li {
+    width: 300px;
+    height: 340px;
+    display: inline-block;
+    vertical-align: top;
+    border: 4px solid grey;
+    margin: 5px 5px 15px 5px;
+}
+
+.event_image img{
+    float: left;
+    height: 200px;
+    width: 292px;
+    margin: 0px 0px 6px 0px;
+}
+
 /*styling using about_image class */
 .about_image img{
     float:left;

--- a/views/fragments/events-list.html
+++ b/views/fragments/events-list.html
@@ -1,9 +1,11 @@
-<ul>
+<ul class="events">
   {% for event in events %}
     <li class="event" id="event-{{event.id}}" style="list-style:none">
-      <a href="/events/{{event.id}}">{{event.title}}:</a>
-      <time datetime="{{event.date}}">{{event.date|prettyDate}}</time>.
-      {{event.attending.length}} attending so far.
+      <a href="/events/{{event.id}}">
+        <div class="event_image"><img src="{{event.image}}"></div>
+        <h4>{{event.title}}</h4></a>
+     <p><time datetime="{{event.date}}">{{event.date|prettyDate}}</time></p>
+     <p>{{event.attending.length}} attending so far</p>
     </li>
   {% endfor %}
 </ul>

--- a/views/index.html
+++ b/views/index.html
@@ -15,7 +15,7 @@
   <p>
     Here are the upcoming events:
   </p>
-  <div style="border: 1px solid blue">
+  <div>
     {% include "fragments/events-list.html" %}
   </div>
   <p>


### PR DESCRIPTION
I changed the formatting of the event list so that the event image is included in the list. It's also formatted so that on most desktops it appears as a 3-column grid, but the number of columns shrinks depending on the width of the window. 

I'll change the images of the events in the next sprint so that there's not so much breaking bad :-)
